### PR TITLE
upgrade to .NET10, adds contrubuting to the update. and version chang…

### DIFF
--- a/GifImporter/CONTRIBUTERS.md
+++ b/GifImporter/CONTRIBUTERS.md
@@ -12,3 +12,5 @@ Compatibility for unix-like filesystem / etc
 Made nice thumbnail when saving gif (first frame instead of entire sprite preview)
 * [989onan](https://github.com/989onan)
 Added support for resdb links and switched from system temp folder
+* [NalaTheThird](https://github.com/nalathethird)
+Recompile for .NET 9/10 - 2025

--- a/GifImporter/GifImporter.cs
+++ b/GifImporter/GifImporter.cs
@@ -19,7 +19,7 @@ public class GifImporter : ResoniteMod
     {
     public override string Name    => "GifImporter";
     public override string Author  => "astral";
-    public override string Version => "1.2.2";
+    public override string Version => "1.2.3";
     public override string Link    => "https://github.com/nalathethird/GifImporter";
 
     [AutoRegisterConfigKey]

--- a/GifImporter/GifImporter.csproj
+++ b/GifImporter/GifImporter.csproj
@@ -3,9 +3,9 @@
     <RootNamespace>GifImporter</RootNamespace>
     <AssemblyName>GifImporter</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <FileAlignment>512</FileAlignment>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
     <!-- Change CopyToMods to true if you'd like builds to be moved into the Mods folder automatically-->


### PR DESCRIPTION
This pull request updates the `GifImporter` mod to ensure compatibility with newer .NET versions and improves contributor documentation. The most important changes are grouped below.

.NET compatibility updates:
* Updated the target framework in `GifImporter.csproj` from `net9.0` to `net10.0`, and set the language version to `latest` for future-proofing.
* Bumped the mod version in `GifImporter.cs` from `1.2.2` to `1.2.3` to reflect these compatibility changes.

Documentation improvements:
* Added a new contributor, `[NalaTheThird](https://github.com/nalathethird)`, to `CONTRIBUTERS.md` and noted the recompilation for .NET 9/10 - 2025.